### PR TITLE
Medal & music kit & rank changer and more

### DIFF
--- a/src/ATGUI/Tabs/misctab.cpp
+++ b/src/ATGUI/Tabs/misctab.cpp
@@ -498,11 +498,11 @@ void Misc::RenderTab()
 				ImGui::Checkbox(XORSTR("AirStuck"), &Settings::Airstuck::enabled);
 				ImGui::Checkbox(XORSTR("Autoblock"), &Settings::Autoblock::enabled);
 				ImGui::Checkbox(XORSTR("Jump Throw"), &Settings::JumpThrow::enabled);
-				ImGui::Checkbox(XORSTR("Door Spam"), &Settings::DoorSpam::enabled);
 				ImGui::Checkbox(XORSTR("Auto Defuse"), &Settings::AutoDefuse::enabled);
 				ImGui::Checkbox(XORSTR("Sniper Crosshair"), &Settings::SniperCrosshair::enabled);
 				ImGui::Checkbox(XORSTR("Disable post-processing"), &Settings::DisablePostProcessing::enabled);
 				ImGui::Checkbox(XORSTR("No Duck Cooldown"), &Settings::NoDuckCooldown::enabled);
+				ImGui::Checkbox(XORSTR("Door Spam"), &Settings::DoorSpam::enabled);
 			}
 			ImGui::NextColumn();
 			{
@@ -514,7 +514,6 @@ void Misc::RenderTab()
 				UI::KeyBindButton(&Settings::Airstuck::key);
 				UI::KeyBindButton(&Settings::Autoblock::key);
 				UI::KeyBindButton(&Settings::JumpThrow::key);
-				UI::KeyBindButton(&Settings::DoorSpam::key);
 				ImGui::Checkbox(XORSTR("Silent Defuse"), &Settings::AutoDefuse::silent);
 				ImGui::Checkbox(XORSTR("Attempt NoFall"), &Settings::NoFall::enabled);
 			}

--- a/src/ATGUI/Tabs/misctab.cpp
+++ b/src/ATGUI/Tabs/misctab.cpp
@@ -17,8 +17,10 @@
 #include "../../Hacks/grenadehelper.h"
 #include "../../Hacks/clantagchanger.h"
 #include "../../Hacks/valvedscheck.h"
+#include "../../Hacks/profilechanger.h"
 
 static char nickname[127] = "";
+static char weapon[50] = "";
 
 void Misc::RenderTab()
 {
@@ -29,6 +31,8 @@ void Misc::RenderTab()
 	const char* grenadeTypes[] = { "FLASH", "SMOKE", "MOLOTOV", "HEGRENADE" };
 	const char* throwTypes[] = { "NORMAL", "RUN", "JUMP", "WALK" };
 	const char* angleTypes[] = { "Real", "Fake" };
+	const char* openSkinFirst[] = { "StatTrak", "Non-StatTrak" };
+	const char* openSkinSecond[] = { "Consumer grade (White)", "Industrial (Light blue)", "Mil-spec (Darker blue)", "Restricted (Purple)", "Classified (Pinkish purple)", "Covert (Red)", "Contraband (Yellow Orange)"};
 
 	ImGui::Columns(2, nullptr, true);
 	{
@@ -409,6 +413,23 @@ void Misc::RenderTab()
 
 				ImGui::EndPopup();
 			}
+
+			if (ImGui::Button(XORSTR("Set Vote-Name")))
+			{
+				std::string votekickGlitch = XORSTR("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+				votekickGlitch += std::string(nickname);
+				votekickGlitch += XORSTR("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+				NameChanger::SetName(votekickGlitch.c_str());
+			}
+			ImGui::SameLine();
+			if (ImGui::Button(XORSTR("Set Banned-Name")))
+			{
+				std::string banNameGlitch = " \x07";
+				banNameGlitch += std::string(nickname);
+				banNameGlitch += XORSTR(" \x07has been permanently banned from official CS:GO servers. \n \n \n \n \n \n \n \n \n \x01⠀You ");
+				NameChanger::SetName(banNameGlitch.c_str());
+			}
+									
 			ImGui::Columns(2, nullptr, true);
 			{
 				if (ImGui::Checkbox(XORSTR("Name Stealer"), &Settings::NameStealer::enabled))
@@ -419,6 +440,52 @@ void Misc::RenderTab()
 				ImGui::Combo("", &Settings::NameStealer::team, teams, IM_ARRAYSIZE(teams));
 			}
 
+			ImGui::Columns(2, nullptr, true);
+			ImGui::Separator();
+			{
+				ImGui::Text(XORSTR("Weapon status:"));
+				ImGui::Text(XORSTR("Weapon rarity:"));
+				ImGui::Text(XORSTR("Weapons  name and skin:"));
+				if (ImGui::Button(XORSTR("Set Skin-Opened-Name"))){
+					std::string skinOpenedGlitch = " \x0B";
+					skinOpenedGlitch += std::string(nickname);
+					skinOpenedGlitch += XORSTR(" \x01has opened a container and found:");
+					if (Settings::ProfileChanger::weaponRarity == 0){
+						skinOpenedGlitch += XORSTR(" \x08"); // Consumer
+					} else if (Settings::ProfileChanger::weaponRarity == 1){
+						skinOpenedGlitch += XORSTR(" \x06"); // Industrial //TODO: Find better color code
+					} else if (Settings::ProfileChanger::weaponRarity == 2){
+						skinOpenedGlitch += XORSTR(" \x0C"); // Mil-Spec
+					} else if (Settings::ProfileChanger::weaponRarity == 3){
+						skinOpenedGlitch += XORSTR(" \x03"); // Restricted
+					} else if (Settings::ProfileChanger::weaponRarity == 4){
+						skinOpenedGlitch += XORSTR(" \x07"); // Classified //TODO: Find better color code
+					} else if (Settings::ProfileChanger::weaponRarity == 5){
+						skinOpenedGlitch += XORSTR(" \x02"); // Covert
+					} else if (Settings::ProfileChanger::weaponRarity == 6){
+						skinOpenedGlitch += XORSTR(" \x10"); // Contraband
+					}
+					if (Settings::ProfileChanger::weaponStatus == 0){
+						skinOpenedGlitch += XORSTR("StatTrak™ ");
+					}
+					skinOpenedGlitch += std::string(weapon);
+					if (Settings::ProfileChanger::weaponStatus == 1 && strlen(weapon) < 12){
+						skinOpenedGlitch += XORSTR(" \n \n \n \n \n \n \n \n \n \n \n \n \n \n \n \n \n \n");
+					} else if (Settings::ProfileChanger::weaponStatus == 1 && strlen(weapon) > 11){
+						skinOpenedGlitch += XORSTR(" \n \n \n \n \n \n \n \n");
+					}
+					skinOpenedGlitch += XORSTR(" \n \n \n \n \n \x01⠀You");
+					NameChanger::SetName(skinOpenedGlitch.c_str());
+				}
+			}
+			ImGui::NextColumn();
+			{
+				ImGui::PushItemWidth(-1);
+				ImGui::Combo("##WEAPONSTATUS", &Settings::ProfileChanger::weaponStatus, openSkinFirst, IM_ARRAYSIZE(openSkinFirst));
+				ImGui::Combo("##WEAPONRARITY", &Settings::ProfileChanger::weaponRarity, openSkinSecond, IM_ARRAYSIZE(openSkinSecond));
+				ImGui::InputText(XORSTR("##WEAPON"), weapon, 50);
+				ImGui::PopItemWidth();
+			}
 			ImGui::Columns(1);
 			ImGui::Separator();
 			ImGui::Text(XORSTR("Other"));
@@ -431,11 +498,11 @@ void Misc::RenderTab()
 				ImGui::Checkbox(XORSTR("AirStuck"), &Settings::Airstuck::enabled);
 				ImGui::Checkbox(XORSTR("Autoblock"), &Settings::Autoblock::enabled);
 				ImGui::Checkbox(XORSTR("Jump Throw"), &Settings::JumpThrow::enabled);
+				ImGui::Checkbox(XORSTR("Door Spam"), &Settings::DoorSpam::enabled);
 				ImGui::Checkbox(XORSTR("Auto Defuse"), &Settings::AutoDefuse::enabled);
 				ImGui::Checkbox(XORSTR("Sniper Crosshair"), &Settings::SniperCrosshair::enabled);
 				ImGui::Checkbox(XORSTR("Disable post-processing"), &Settings::DisablePostProcessing::enabled);
 				ImGui::Checkbox(XORSTR("No Duck Cooldown"), &Settings::NoDuckCooldown::enabled);
-				ImGui::Checkbox(XORSTR("Door Spam"), &Settings::DoorSpam::enabled);
 			}
 			ImGui::NextColumn();
 			{
@@ -447,12 +514,25 @@ void Misc::RenderTab()
 				UI::KeyBindButton(&Settings::Airstuck::key);
 				UI::KeyBindButton(&Settings::Autoblock::key);
 				UI::KeyBindButton(&Settings::JumpThrow::key);
+				UI::KeyBindButton(&Settings::DoorSpam::key);
 				ImGui::Checkbox(XORSTR("Silent Defuse"), &Settings::AutoDefuse::silent);
 				ImGui::Checkbox(XORSTR("Attempt NoFall"), &Settings::NoFall::enabled);
 			}
 			ImGui::Columns(1);
 			ImGui::Separator();
 
+			ImGui::Text(XORSTR("Profile Changer"));
+			ImGui::Separator();
+			ImGui::Columns(1, nullptr, true);
+			{
+				ImGui::InputInt(XORSTR("COIN##ID"), &Settings::ProfileChanger::coinID);
+				ImGui::InputInt(XORSTR("MUSIC KIT##ID"), &Settings::ProfileChanger::musicID);
+				ImGui::InputInt(XORSTR("COMP RANK##ID"), &Settings::ProfileChanger::compRank);
+				if (ImGui::Button(XORSTR("Update profile"), ImVec2(-1, 0)))
+					ProfileChanger::UpdateProfile();
+			}
+			ImGui::Columns(1);
+			ImGui::Separator();
 			ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(210, 85));
 			if (ImGui::BeginPopupModal(XORSTR("Error###UNTRUSTED_FEATURE")))
 			{

--- a/src/Hacks/profilechanger.cpp
+++ b/src/Hacks/profilechanger.cpp
@@ -1,0 +1,28 @@
+#include "profilechanger.h"
+
+#include "../settings.h"
+#include "../interfaces.h"
+
+int Settings::ProfileChanger::coinID = 890;
+int Settings::ProfileChanger::musicID = 10;
+int Settings::ProfileChanger::compRank = 18;
+int Settings::ProfileChanger::weaponStatus = 0;
+int Settings::ProfileChanger::weaponRarity = 0;
+
+void ProfileChanger::UpdateProfile()
+{
+	if (!engine->IsInGame())
+		return;
+
+	C_BasePlayer* localplayer = (C_BasePlayer*) entityList->GetClientEntity(engine->GetLocalPlayer());
+	if (!localplayer)
+		return;
+
+	const auto local_index = localplayer->GetIndex();
+
+	if (auto player_resource = *csPlayerResource){
+		player_resource->SetActiveCoinRank()[local_index] = Settings::ProfileChanger::coinID;
+		player_resource->SetMusicID()[local_index] = Settings::ProfileChanger::musicID;
+		player_resource->SetCompetitiveRanking()[local_index] = Settings::ProfileChanger::compRank;
+	}
+}

--- a/src/Hacks/profilechanger.h
+++ b/src/Hacks/profilechanger.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "../SDK/IInputSystem.h"
+
+namespace ProfileChanger
+{
+	void UpdateProfile();
+}

--- a/src/SDK/CPlayerResource.h
+++ b/src/SDK/CPlayerResource.h
@@ -75,6 +75,11 @@ public:
 		return (int*)((uintptr_t)this + offsets.DT_CSPlayerResource.m_iCompetitiveRanking + index * 4);
 	}
 
+	int* SetCompetitiveRanking()
+	{
+		return (int*)((uintptr_t)this + offsets.DT_CSPlayerResource.m_iCompetitiveRanking);
+	}
+
 	int* GetCompetitiveWins(int index)
 	{
 		return (int*)((uintptr_t)this + offsets.DT_CSPlayerResource.m_iCompetitiveWins + index * 4);
@@ -95,10 +100,20 @@ public:
 		return (int*)((uintptr_t)this + offsets.DT_CSPlayerResource.m_nActiveCoinRank + index * 4);
 	}
 
+	int* SetActiveCoinRank()
+	{
+		return (int*)((uintptr_t)this + offsets.DT_CSPlayerResource.m_nActiveCoinRank);
+	}
+
 	int* GetMusicID(int index)
 	{
 		return (int*)((uintptr_t)this + offsets.DT_CSPlayerResource.m_nMusicID + index * 4);
 	}
+
+	int* SetMusicID()
+	{
+		return (int*)((uintptr_t)this + offsets.DT_CSPlayerResource.m_nMusicID);
+	}		
 
 	int* GetPersonaDataPublicCommendsLeader(int index)
 	{

--- a/src/SDK/IClientEntity.h
+++ b/src/SDK/IClientEntity.h
@@ -494,6 +494,21 @@ public:
 	{
 		return *(int*)((uintptr_t)this + offsets.DT_PlantedC4.m_hBombDefuser);
 	}
+
+	float GetBombDefuseCountDown()
+	{
+		return *(float*)((uintptr_t)this + offsets.DT_PlantedC4.m_flDefuseCountDown);
+	}
+		
+	float GetDefuseLenght()
+	{
+		return *(float*)((uintptr_t)this + offsets.DT_PlantedC4.m_flDefuseLength);
+	}	
+
+	int GetBombSite()
+	{
+		return *(int*)((uintptr_t)this + offsets.DT_PlantedC4.m_nBombSite);
+	} 	
 };
 
 class C_BaseAttributableItem : public C_BaseEntity

--- a/src/offsets.cpp
+++ b/src/offsets.cpp
@@ -83,6 +83,9 @@ void Offsets::GetNetVarOffsets()
 	offsets.DT_PlantedC4.m_flC4Blow = NetVarManager::GetOffset(tables, XORSTR("DT_PlantedC4"), XORSTR("m_flC4Blow"));
 	offsets.DT_PlantedC4.m_bBombDefused = NetVarManager::GetOffset(tables, XORSTR("DT_PlantedC4"), XORSTR("m_bBombDefused"));
 	offsets.DT_PlantedC4.m_hBombDefuser = NetVarManager::GetOffset(tables, XORSTR("DT_PlantedC4"), XORSTR("m_hBombDefuser"));
+	offsets.DT_PlantedC4.m_flDefuseCountDown = NetVarManager::GetOffset(tables, XORSTR("DT_PlantedC4"), XORSTR("m_flDefuseCountDown"));
+	offsets.DT_PlantedC4.m_flDefuseLength = NetVarManager::GetOffset(tables, XORSTR("DT_PlantedC4"), XORSTR("m_flDefuseLength"));
+	offsets.DT_PlantedC4.m_nBombSite = NetVarManager::GetOffset(tables, XORSTR("DT_PlantedC4"), XORSTR("m_nBombSite"));
 
 	offsets.DT_CSPlayer.m_iShotsFired = NetVarManager::GetOffset(tables, XORSTR("DT_CSPlayer"), XORSTR("m_iShotsFired"));
 	offsets.DT_CSPlayer.m_angEyeAngles[0] = NetVarManager::GetOffset(tables, XORSTR("DT_CSPlayer"), XORSTR("m_angEyeAngles[0]"));

--- a/src/offsets.h
+++ b/src/offsets.h
@@ -96,6 +96,9 @@ struct COffsets
 		std::ptrdiff_t m_flC4Blow;
 		std::ptrdiff_t m_bBombDefused;
 		std::ptrdiff_t m_hBombDefuser;
+		std::ptrdiff_t m_flDefuseCountDown;
+		std::ptrdiff_t m_flDefuseLength;		
+		std::ptrdiff_t m_nBombSite;			
 	} DT_PlantedC4;
 
 	struct

--- a/src/settings.h
+++ b/src/settings.h
@@ -1111,9 +1111,8 @@ namespace Settings
 	namespace DoorSpam
 	{
 		extern bool enabled;
-		extern ButtonCode_t key;
 	}
-	
+
 	namespace NoFall
 	{
 		extern bool enabled;

--- a/src/settings.h
+++ b/src/settings.h
@@ -1112,7 +1112,7 @@ namespace Settings
 	{
 		extern bool enabled;
 	}
-
+  
 	namespace NoFall
 	{
 		extern bool enabled;

--- a/src/settings.h
+++ b/src/settings.h
@@ -1099,11 +1099,21 @@ namespace Settings
 		extern ButtonCode_t key;
 	}
 
+	namespace ProfileChanger
+	{
+		extern int coinID;
+		extern int musicID;
+		extern int compRank;
+		extern int weaponStatus;
+		extern int weaponRarity;
+	}
+
 	namespace DoorSpam
 	{
 		extern bool enabled;
+		extern ButtonCode_t key;
 	}
-  
+	
 	namespace NoFall
 	{
 		extern bool enabled;


### PR DESCRIPTION
Adding medal, music kit and rank changer (client side!, working on protobuf).
Also adds 3 troll features - Vote kick 'glitch', Ban name 'glitch' and Skin received troll name
Troll features are based on name changing. Sometimes it can lead to the weird effects but perfectly choosen nick name and weapon name can be a good troll. (In nickname input You choose nickname in the message also for the text of vote kick)
It also adds some missing offsets to planted bomb (ex. of usage is defuse timer bar on screen, I could add it because I have it done already)
Profile Changer (music id medal and rank) works but only client side, you can hear music kits, preview medal only on scoreboard and look at the spoofed rank.
Preview of these features: https://i.imgur.com/oQdUvAI.png https://www.youtube.com/watch?v=D0ZujGF3e-M (yes I took an idea from this film)